### PR TITLE
Apply a locale while formatting dates and numbers

### DIFF
--- a/dist/modules/index.js
+++ b/dist/modules/index.js
@@ -34,11 +34,11 @@ export function __select(value, opts) {
     return opts[value] || opts['other'] || '';
 }
 export function __number(value, format) {
-    return formatNumber(value, { format });
+    return formatNumber(value, { format, locale: getCurrentLocale() });
 }
 export function __date(value, format = "short") {
-    return formatDate(value, { format });
+    return formatDate(value, { format, locale: getCurrentLocale() });
 }
 export function __time(value, format = "short") {
-    return formatTime(value, { format });
+    return formatTime(value, { format, locale: getCurrentLocale() });
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,13 +68,13 @@ export function __select(value: any, opts: Record<any, string>): string {
 }
 
 export function __number(value: number, format?: string): string {
-  return formatNumber(value, { format });
+  return formatNumber(value, { locale: getCurrentLocale(), format });
 }
 
 export function __date(value: Date, format = "short"): string {
-  return formatDate(value, { format });
+  return formatDate(value, { format, locale: getCurrentLocale() });
 }
 
 export function __time(value: Date, format = "short"): string {
-  return formatTime(value, { format });
+  return formatTime(value, { format, locale: getCurrentLocale() });
 }

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -121,6 +121,14 @@ describe('__date', function() {
     let wedding = new Date('2013-10-18');
     expect(__date(wedding, "abbr-full")).toBe("Friday, Oct 18");
   });
+
+  it('honours current locale setting', function() {
+    let disaster = new Date('1986-01-28');
+    locale.set("en");
+    expect(__date(disaster)).toBe("1/28/86");
+    locale.set("de");
+    expect(__date(disaster)).toBe("28.1.86");
+  });
 });
 
 describe("__time", function() {
@@ -141,12 +149,21 @@ describe("__time", function() {
     let wedding = new Date(Date.UTC(2013, 11, 18, 19, 13, 50));
     expect(__time(wedding, "hour")).toBe("8 PM");
   });
+
+  it('honours current locale setting', function() {
+    let wedding = new Date(Date.UTC(2013, 11, 18, 19, 13, 50));
+    expect(__time(wedding, "hour")).toBe("8 PM");
+    locale.set("de");
+    expect(__time(wedding, "hour")).toBe("20 Uhr");
+  });
 });
 
 describe("__number", function() {
   it('formats numbers in the current\'s locale way', function() {
     expect(__number(12345678)).toBe("12,345,678");
-  });
+    locale.set("de");
+    expect(__number(12345678)).toBe("12.345.678");
+    });
 
   it('accepts "scientific", "engineering", "compactLong" and "compactShort" as second argument', function() {
     expect(__number(12345678, "scientific")).toBe("1.235E7");


### PR DESCRIPTION
I've noticed that dates, time and numbers are always formatted according to initial locale, not the selected one.

It appeared a memoized formatter is shared by all locales.

I've updated caller functions to pass a current locale to createFormatter functions. This way a memoization wrapper may return or create a proper formatter for given locale.

The issue was happening if locale was set in runtime and if the locale is not the same as initial one.