### PR TITLE
Allow nested messages and id's. Backwards compatible.

### DIFF
--- a/src/stores/dictionary.ts
+++ b/src/stores/dictionary.ts
@@ -1,6 +1,7 @@
 // @ts-ignore
 import { writable, derived } from 'svelte/store';
-import { LocaleDictionary, DeepDictionary, Dictionary } from '../types/index';
+import { LocaleDictionary, LocaleDictionaryValue, DeepDictionary, Dictionary }
+  from '../types/index';
 import { getPossibleLocales } from '../includes/utils';
 
 let dictionary: Dictionary
@@ -23,6 +24,15 @@ export function getMessageFromDictionary(locale: string, id: string) {
     const localeDictionary = getLocaleDictionary(locale)
     if (id in localeDictionary) {
       return localeDictionary[id]
+    }
+
+    const ids = id.split('.')
+    let tmpDict: any = localeDictionary
+    for (let i = 0; i < ids.length; i++) {
+      if (typeof tmpDict[ids[i]] !== 'object') {
+        return (tmpDict[ids[i]] as LocaleDictionaryValue) || null
+      }
+      tmpDict = tmpDict[ids[i]];
     }
   }
   return null

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -200,10 +200,20 @@ describe("addMessages", function() {
 
 describe("format", function() {
   it('translates the given messages on the current locale', () => {
-    addMessages("en-US", { simple: "Hello", complex: (a, b) => `This is a function that interpolates ${b} and ${a}` });
+    addMessages("en-US", {
+      simple: "Hello",
+      nested: {
+        deep: "Goodbye"
+      },
+      "nested.fake": "Greetings",
+      complex: (a, b) => `This is a function that interpolates ${b} and ${a}`
+    });
     let unsubscribe = format.subscribe(t => {
       expect(t("simple")).toBe("Hello");
-      expect(t("complex", { values: { a: 'HA', b: "BO" } })).toBe("This is a function that interpolates BO and HA");
+      expect(t("nested.deep")).toBe("Goodbye");
+      expect(t("nested.fake")).toBe("Greetings");
+      expect(t("complex", { values: { a: 'HA', b: "BO" } }))
+        .toBe("This is a function that interpolates BO and HA");
     });
     unsubscribe()
   });


### PR DESCRIPTION
Allow nested messages and id's. Backwards compatible.

Example messages:

```
{
  dinner: {
    main: {
      food: 'pizza'
    }
  }
}
```

Example key: `$t('dinner.main.food')`.

With working tests:

`npm run test -- -t "^format"`