### PR TITLE
Remove id from MessageObject interface when passed as second parameter

### DIFF
--- a/dist/modules/stores/formatters.js
+++ b/dist/modules/stores/formatters.js
@@ -1,4 +1,3 @@
-// @ts-ignore
 import { derived } from "svelte/store";
 import { lookup } from '../includes/lookup';
 import { hasLocaleQueue } from '../includes/loaderQueue';
@@ -6,11 +5,9 @@ import { getTimeFormatter, getDateFormatter, getNumberFormatter, } from '../incl
 import { getOptions, getCurrentLocale, getPossibleLocales } from '../includes/utils';
 import { $dictionary } from './dictionary';
 import { $locale } from './locale';
-export const formatMessage = (id, options = { id: '#missing-message-id#' }) => {
-    if (typeof id === 'object') {
-        options = id;
-        id = options.id;
-    }
+export const formatMessage = (optionsOrId, maybeOptions = {}) => {
+    const id = typeof optionsOrId === 'string' ? optionsOrId : optionsOrId.id;
+    const options = typeof optionsOrId === 'string' ? maybeOptions : optionsOrId;
     const { values, locale = getCurrentLocale(), default: defaultValue, } = options;
     if (locale == null) {
         throw new Error('[svelte-i18n] Cannot format a message without first setting the initial locale.');

--- a/dist/modules/types/index.d.ts
+++ b/dist/modules/types/index.d.ts
@@ -10,14 +10,16 @@ export declare type LocaleDictionaryValue = string | ((...args: any[]) => string
 export declare type LocaleDictionary = Record<string, LocaleDictionaryValue>;
 export declare type Dictionary = Record<string, LocaleDictionary>;
 export interface MessageObject {
-    id: string;
     locale?: string;
     format?: string;
     default?: string;
     values?: Record<string, string | number | Date>;
 }
+export interface MessageObjectWithId extends MessageObject {
+    id: string;
+}
 export declare type JsonGetter = (id: string, locale?: string) => any;
-export declare type MessageFormatter = (id: string | MessageObject, options?: MessageObject) => string;
+export declare type MessageFormatter = (id: string | MessageObjectWithId, options?: MessageObject) => string;
 export declare type TimeFormatter = (d: Date | number, options?: IntlFormatterOptions<Intl.DateTimeFormatOptions>) => string;
 export declare type DateFormatter = (d: Date | number, options?: IntlFormatterOptions<Intl.DateTimeFormatOptions>) => string;
 export declare type NumberFormatter = (d: number, options?: IntlFormatterOptions<Intl.NumberFormatOptions>) => string;

--- a/src/stores/formatters.ts
+++ b/src/stores/formatters.ts
@@ -1,4 +1,3 @@
-// @ts-ignore
 import { derived } from "svelte/store";
 
 import {
@@ -8,6 +7,7 @@ import {
   DateFormatter,
   NumberFormatter,
   JsonGetter,
+  MessageObjectWithId,
 } from '../types/index'
 import { lookup } from '../includes/lookup'
 import { hasLocaleQueue } from '../includes/loaderQueue'
@@ -21,11 +21,9 @@ import { getOptions, getCurrentLocale, getPossibleLocales } from '../includes/ut
 import { $dictionary } from './dictionary'
 import { $locale } from './locale'
 
-export const formatMessage: MessageFormatter = (id, options = {id: '#missing-message-id#'}) => {
-  if (typeof id === 'object') {
-    options = id as MessageObject;
-    id = options.id;
-  }
+export const formatMessage: MessageFormatter = (optionsOrId, maybeOptions= {}) => {
+  const id = typeof optionsOrId === 'string' ? optionsOrId : optionsOrId.id;
+  const options = typeof optionsOrId === 'string' ? maybeOptions : optionsOrId;
 
   const {
     values,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -12,11 +12,14 @@ export type LocaleDictionary = Record<string, LocaleDictionaryValue>;
 export type Dictionary = Record<string, LocaleDictionary>
 
 export interface MessageObject {
-  id: string
   locale?: string
   format?: string
   default?: string
   values?: Record<string, string | number | Date>
+}
+
+export interface MessageObjectWithId extends MessageObject {
+  id: string
 }
 
 export type JsonGetter = (
@@ -25,7 +28,7 @@ export type JsonGetter = (
 ) => any
 
 export type MessageFormatter = (
-  id: string | MessageObject,
+  id: string | MessageObjectWithId,
   options?: MessageObject
 ) => string
 


### PR DESCRIPTION
Currently I have a problem in the following code: 
```
$t('components.change_password_form.password_is_too_short', {
	values: { limit: PASSWORD_MIN_LENGTH }
})
```
$t function expects id to be passed in MessageObject despite it's specified in the first parameter