### PR TITLE
fix: add main package.json field

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "build": "tsc -p tsconfig.json && tsc -p tsconfig-cjs.json",
     "test": "TZ=utc jest test"
   },
+  "main": "dist/commonjs/index.js",
   "module": "dist/modules/index.js",
   "types": "dist/modules/index.d.ts",
   "peerDependencies": {


### PR DESCRIPTION
With this fix it is possible to `require('precompile-intl-runtime')` .