### PR TITLE
Add getLocaleFromAcceptLanguageHeader for server side locale detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
 .DS_Store
 .vscode
+.idea
 dist

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,3 +1,5 @@
+## next
+- Add getLocaleFromAcceptLanguageHeader for server side locale detection 
 ## 0.4.14
 - Make some types more strict
 ## 0.4.11

--- a/dist/modules/includes/localeGetters.d.ts
+++ b/dist/modules/includes/localeGetters.d.ts
@@ -3,3 +3,4 @@ export declare const getLocaleFromPathname: (pathname: RegExp) => string | null;
 export declare const getLocaleFromNavigator: (ssrDefault?: string | undefined) => string | null;
 export declare const getLocaleFromQueryString: (search: string) => string | null;
 export declare const getLocaleFromHash: (hash: string) => string | null;
+export declare const getLocaleFromAcceptLanguageHeader: (header: string | null, availableLocales?: string[] | undefined) => string | null;

--- a/dist/modules/includes/localeGetters.d.ts
+++ b/dist/modules/includes/localeGetters.d.ts
@@ -3,4 +3,4 @@ export declare const getLocaleFromPathname: (pathname: RegExp) => string | null;
 export declare const getLocaleFromNavigator: (ssrDefault?: string | undefined) => string | null;
 export declare const getLocaleFromQueryString: (search: string) => string | null;
 export declare const getLocaleFromHash: (hash: string) => string | null;
-export declare const getLocaleFromAcceptLanguageHeader: (header: string | null, availableLocales?: string[] | undefined) => string | null;
+export declare const getLocaleFromAcceptLanguageHeader: (header: string | null, availableLocales?: string[] | undefined) => string | undefined;

--- a/dist/modules/includes/localeGetters.js
+++ b/dist/modules/includes/localeGetters.js
@@ -61,17 +61,18 @@ export const getLocaleFromAcceptLanguageHeader = (header, availableLocales) => {
     })
         .sort((a, b) => b.quality - a.quality);
     // If availableLocales is not defined return the first language from header
-    if (!availableLocales)
+    if (!availableLocales || availableLocales.length === 0)
         return locales[0].locale;
+    availableLocales = availableLocales.map(l => l.toLowerCase());
     // Check full match
     for (const locale of locales) {
-        if (availableLocales.includes(locale.locale))
+        if (availableLocales.includes(locale.locale.toLowerCase()))
             return locale.locale;
     }
     // Check base language match
     for (const locale of locales.filter(l => l.locale.includes('-'))) {
         const base = locale.locale.split('-')[0];
-        if (availableLocales.includes(base))
+        if (availableLocales.includes(base.toLowerCase()))
             return base;
     }
     // If no match found use fallbackLocale

--- a/dist/modules/includes/localeGetters.js
+++ b/dist/modules/includes/localeGetters.js
@@ -44,3 +44,36 @@ export const getLocaleFromHash = (hash) => {
         return null;
     return getFromQueryString(window.location.hash.substr(1), hash);
 };
+export const getLocaleFromAcceptLanguageHeader = (header, availableLocales) => {
+    // If header is null (i.e. does not exist) the fallbackLocale should be used
+    if (!header)
+        return null;
+    // Parse Accept-Language header
+    const locales = header
+        .split(',')
+        .map(locale => locale.trim())
+        .map(locale => {
+        const directives = locale.split(';q=');
+        return {
+            locale: directives[0],
+            quality: parseFloat(directives[1]) || 1.0
+        };
+    })
+        .sort((a, b) => b.quality - a.quality);
+    // If availableLocales is not defined return the first language from header
+    if (!availableLocales)
+        return locales[0].locale;
+    // Check full match
+    for (const locale of locales) {
+        if (availableLocales.includes(locale.locale))
+            return locale.locale;
+    }
+    // Check base language match
+    for (const locale of locales.filter(l => l.locale.includes('-'))) {
+        const base = locale.locale.split('-')[0];
+        if (availableLocales.includes(base))
+            return base;
+    }
+    // If no match found use fallbackLocale
+    return null;
+};

--- a/dist/modules/includes/localeGetters.js
+++ b/dist/modules/includes/localeGetters.js
@@ -47,7 +47,7 @@ export const getLocaleFromHash = (hash) => {
 export const getLocaleFromAcceptLanguageHeader = (header, availableLocales) => {
     // If header is null (i.e. does not exist) the fallbackLocale should be used
     if (!header)
-        return null;
+        return undefined;
     // Parse Accept-Language header
     const locales = header
         .split(',')
@@ -75,5 +75,5 @@ export const getLocaleFromAcceptLanguageHeader = (header, availableLocales) => {
             return base;
     }
     // If no match found use fallbackLocale
-    return null;
+    return undefined;
 };

--- a/src/includes/localeGetters.ts
+++ b/src/includes/localeGetters.ts
@@ -55,10 +55,10 @@ export const getLocaleFromHash = (hash: string) => {
   return getFromQueryString(window.location.hash.substr(1), hash);
 };
 
-export const getLocaleFromAcceptLanguageHeader = (header: string | null, availableLocales?: string[]): string | null => {
+export const getLocaleFromAcceptLanguageHeader = (header: string | null, availableLocales?: string[]): string | undefined => {
   // If header is null (i.e. does not exist) the fallbackLocale should be used
   if (!header)
-    return null;
+    return undefined;
 
   // Parse Accept-Language header
   const locales = header
@@ -91,5 +91,5 @@ export const getLocaleFromAcceptLanguageHeader = (header: string | null, availab
   }
 
   // If no match found use fallbackLocale
-  return null;
+  return undefined;
 }

--- a/src/includes/localeGetters.ts
+++ b/src/includes/localeGetters.ts
@@ -74,19 +74,21 @@ export const getLocaleFromAcceptLanguageHeader = (header: string | null, availab
       .sort((a, b) => b.quality - a.quality);
 
   // If availableLocales is not defined return the first language from header
-  if (!availableLocales)
+  if (!availableLocales || availableLocales.length === 0)
     return locales[0].locale;
+
+  availableLocales = availableLocales.map(l => l.toLowerCase());
 
   // Check full match
   for (const locale of locales) {
-    if (availableLocales.includes(locale.locale))
+    if (availableLocales.includes(locale.locale.toLowerCase()))
       return locale.locale;
   }
 
   // Check base language match
   for (const locale of locales.filter(l => l.locale.includes('-'))) {
     const base = locale.locale.split('-')[0];
-    if (availableLocales.includes(base))
+    if (availableLocales.includes(base.toLowerCase()))
       return base;
   }
 

--- a/tests/localeGetters.test.js
+++ b/tests/localeGetters.test.js
@@ -1,0 +1,17 @@
+import {getLocaleFromAcceptLanguageHeader} from "../dist/modules";
+
+describe('getLocaleFromAcceptLanguageHeader', () => {
+  it.each([
+    {header: 'en-GB,en;q=0.9,es-ES;q=0.8,en-US;q=0.6', availableLocales: undefined, expected: 'en-GB'},
+    {header: 'en-GB,en;q=0.9,es-ES;q=0.8,en-US;q=0.6', availableLocales: [], expected: 'en-GB'},
+    {header: 'en-GB,en;q=0.9,es-ES;q=0.8,en-US;q=0.6', availableLocales: ['es-ES', 'en-us'], expected: 'es-ES'},
+    {header: 'en-GB,en;q=0.9,es-ES;q=0.8,en-US;q=0.6', availableLocales: ['es', 'en-us'], expected: 'en-us'},
+    {header: 'en-GB,en;q=0.9,es-ES;q=0.8,en-US;q=0.6', availableLocales: ['es', 'de'], expected: 'es'},
+    {header: 'en-GB,en;q=0.9,es-ES;q=0.8,en-US;q=0.6', availableLocales: ['de'], expected: undefined},
+    {header: null, availableLocales: ['en-US'], expected: undefined},
+    {header: '', availableLocales: ['en-US'], expected: undefined},
+  ])('header: $header; availableLocales: $availableLocales', ({header, availableLocales, expected}) => {
+    const result = getLocaleFromAcceptLanguageHeader(header, availableLocales);
+    expect(result?.toLowerCase()).toEqual(expected?.toLowerCase());
+  });
+});


### PR DESCRIPTION
In the last few days, I have been working on the optimization of i18n in connection with server-side rendering. For this, I created a function to set initialLocale based on the Accept-Language header of the user. With such a solution the server-side rendered page already contains the correct strings.

I have added this localeGetter function:
```typescript
function getLocaleFromAcceptLanguageHeader(header: string | null, availableLocales?: string[]): string | undefined
```

The first parameter is the value from the `Accept-Language` Header. The second parameter is a string array with all locales that are available in the application. If the second parameter is omitted the function returns the first locale from the header string. In the case that no locale can be determined, the function returns `undefined`.

---

With SvelteKit you can use this function inside the `getSession` hook.

```typescript
export const getSession: GetSession = async (event: RequestEvent) => {
  const locale = getLocaleFromAcceptLanguageHeader(event.request.headers.get('accept-language'), availableLocales);
  return {locale};
};
```

In the `__layout.svelte` you can now set the `initialLocale` based on the `session`  in the `load` function.

```typescript
export const load: Load = async ({session}) => {
  init({
    initialLocale: session['locale'],
    fallbackLocale: 'en'
  });
  await waitLocale();
  return {};
};
```

If you accept this Pull Request, I can extend the documentation also.