### PR TITLE
Update getMessageFromDictionary to be aligned with svelte-i18n. This …

### DIFF
--- a/dist/modules/stores/dictionary.d.ts
+++ b/dist/modules/stores/dictionary.d.ts
@@ -1,9 +1,9 @@
-import { LocaleDictionary, LocaleDictionaryValue, DeepDictionary, Dictionary } from '../types/index';
+import { LocaleDictionary, DeepDictionary, Dictionary } from '../types/index';
 declare const $dictionary: import("svelte/store").Writable<Dictionary>;
 export declare function getLocaleDictionary(locale: string): LocaleDictionary;
 export declare function getDictionary(): Dictionary;
 export declare function hasLocaleDictionary(locale: string): boolean;
-export declare function getMessageFromDictionary(locale: string, id: string): LocaleDictionaryValue | null;
+export declare function getMessageFromDictionary(locale: string, id: string): any;
 export declare function getClosestAvailableLocale(refLocale: string): string | null;
 export declare function addMessages(locale: string, ...partials: DeepDictionary[]): void;
 declare const $locales: import("svelte/store").Readable<string[]>;

--- a/dist/modules/stores/dictionary.js
+++ b/dist/modules/stores/dictionary.js
@@ -1,6 +1,7 @@
 // @ts-ignore
 import { writable, derived } from 'svelte/store';
 import { getPossibleLocales } from '../includes/utils';
+import { delve } from '../shared/delve';
 let dictionary;
 const $dictionary = writable({});
 export function getLocaleDictionary(locale) {
@@ -13,21 +14,12 @@ export function hasLocaleDictionary(locale) {
     return locale in dictionary;
 }
 export function getMessageFromDictionary(locale, id) {
-    if (hasLocaleDictionary(locale)) {
-        const localeDictionary = getLocaleDictionary(locale);
-        if (id in localeDictionary) {
-            return localeDictionary[id];
-        }
-        const ids = id.split('.');
-        let tmpDict = localeDictionary;
-        for (let i = 0; i < ids.length; i++) {
-            if (typeof tmpDict[ids[i]] !== 'object') {
-                return tmpDict[ids[i]] || null;
-            }
-            tmpDict = tmpDict[ids[i]];
-        }
+    if (!hasLocaleDictionary(locale)) {
+        return null;
     }
-    return null;
+    const localeDictionary = getLocaleDictionary(locale);
+    const match = delve(localeDictionary, id);
+    return match;
 }
 export function getClosestAvailableLocale(refLocale) {
     if (refLocale == null)

--- a/src/shared/delve.ts
+++ b/src/shared/delve.ts
@@ -1,0 +1,29 @@
+export function delve(obj: Record<string, unknown>, fullKey?: string) {
+    if (fullKey == null) return undefined;
+  
+    if (fullKey in obj) {
+      return obj[fullKey];
+    }
+  
+    const keys = fullKey.split('.');
+    let result: any = obj;
+  
+    for (let p = 0; p < keys.length; p++) {
+      if (typeof result === 'object') {
+        if (p > 0) {
+          const partialKey = keys.slice(p, keys.length).join('.');
+  
+          if (partialKey in result) {
+            result = result[partialKey];
+            break;
+          }
+        }
+  
+        result = result[keys[p]];
+      } else {
+        result = undefined;
+      }
+    }
+  
+    return result;
+  }

--- a/src/stores/dictionary.ts
+++ b/src/stores/dictionary.ts
@@ -3,6 +3,7 @@ import { writable, derived } from 'svelte/store';
 import { LocaleDictionary, LocaleDictionaryValue, DeepDictionary, Dictionary }
   from '../types/index';
 import { getPossibleLocales } from '../includes/utils';
+import { delve } from '../shared/delve';
 
 let dictionary: Dictionary
 const $dictionary = writable<Dictionary>({})
@@ -19,23 +20,17 @@ export function hasLocaleDictionary(locale: string) {
   return locale in dictionary
 }
 
-export function getMessageFromDictionary(locale: string, id: string) {
-  if (hasLocaleDictionary(locale)) {
-    const localeDictionary = getLocaleDictionary(locale)
-    if (id in localeDictionary) {
-      return localeDictionary[id]
-    }
 
-    const ids = id.split('.')
-    let tmpDict: any = localeDictionary
-    for (let i = 0; i < ids.length; i++) {
-      if (typeof tmpDict[ids[i]] !== 'object') {
-        return (tmpDict[ids[i]] as LocaleDictionaryValue) || null
-      }
-      tmpDict = tmpDict[ids[i]];
-    }
+export function getMessageFromDictionary(locale: string, id: string) {
+  if (!hasLocaleDictionary(locale)) {
+    return null;
   }
-  return null
+
+  const localeDictionary = getLocaleDictionary(locale);
+
+  const match = delve(localeDictionary, id);
+
+  return match;
 }
 
 


### PR DESCRIPTION
…allows a better drop in replacement.

This should solve [this issue](https://github.com/cibernox/svelte-intl-precompile/issues/47) once it's merged in here and the version is bumped in svelte-intl-precompile.