### PR TITLE
Extend getLocaleFromAcceptLanguageHeader to match more use cases

### DIFF
--- a/dist/modules/includes/localeGetters.js
+++ b/dist/modules/includes/localeGetters.js
@@ -63,18 +63,51 @@ export const getLocaleFromAcceptLanguageHeader = (header, availableLocales) => {
     // If availableLocales is not defined return the first language from header
     if (!availableLocales || availableLocales.length === 0)
         return locales[0].locale;
-    availableLocales = availableLocales.map(l => l.toLowerCase());
-    // Check full match
+    locales.forEach(l => l.locale = l.locale.toLowerCase());
+    let firstAvailableBaseMatch;
+    // Check languages
     for (const locale of locales) {
-        if (availableLocales.includes(locale.locale.toLowerCase()))
-            return locale.locale;
+        if (firstAvailableBaseMatch && !locale.locale.toLowerCase().startsWith(`${firstAvailableBaseMatch.base}-`)) {
+            continue;
+        }
+        // Full match
+        const fullMatch = getArrayElementCaseInsensitive(availableLocales, locale.locale);
+        if (fullMatch) {
+            return fullMatch;
+        }
+        if (firstAvailableBaseMatch) {
+            continue;
+        }
+        // header base match
+        const baseMatch = getArrayElementCaseInsensitive(availableLocales, locale.locale.split('-')[0]);
+        if (baseMatch) {
+            return baseMatch;
+        }
+        // available base match
+        for (const availableLocale of availableLocales) {
+            const availableBase = availableLocale.split('-')[0];
+            if (availableBase.toLowerCase() === locale.locale) {
+                // Remember base match to check if full match with same base exists
+                firstAvailableBaseMatch = {
+                    match: availableLocale,
+                    base: locale.locale
+                };
+                break;
+            }
+        }
     }
-    // Check base language match
-    for (const locale of locales.filter(l => l.locale.includes('-'))) {
-        const base = locale.locale.split('-')[0];
-        if (availableLocales.includes(base.toLowerCase()))
-            return base;
+    if (firstAvailableBaseMatch !== undefined) {
+        return firstAvailableBaseMatch.match;
     }
     // If no match found use fallbackLocale
     return undefined;
 };
+function getArrayElementCaseInsensitive(array, searchElement) {
+    searchElement = searchElement.toLowerCase();
+    for (const element of array) {
+        if (element.toLowerCase() === searchElement) {
+            return element;
+        }
+    }
+    return undefined;
+}

--- a/tests/localeGetters.test.js
+++ b/tests/localeGetters.test.js
@@ -2,16 +2,21 @@ import {getLocaleFromAcceptLanguageHeader} from "../dist/modules";
 
 describe('getLocaleFromAcceptLanguageHeader', () => {
   it.each([
-    {header: 'en-GB,en;q=0.9,es-ES;q=0.8,en-US;q=0.6', availableLocales: undefined, expected: 'en-GB'},
-    {header: 'en-GB,en;q=0.9,es-ES;q=0.8,en-US;q=0.6', availableLocales: [], expected: 'en-GB'},
-    {header: 'en-GB,en;q=0.9,es-ES;q=0.8,en-US;q=0.6', availableLocales: ['es-ES', 'en-us'], expected: 'es-ES'},
-    {header: 'en-GB,en;q=0.9,es-ES;q=0.8,en-US;q=0.6', availableLocales: ['es', 'en-us'], expected: 'en-us'},
-    {header: 'en-GB,en;q=0.9,es-ES;q=0.8,en-US;q=0.6', availableLocales: ['es', 'de'], expected: 'es'},
+    {header: 'en-GB,en;q=0.9,es-ES;q=0.8', availableLocales: undefined, expected: 'en-GB'},
+    {header: 'en-GB,en;q=0.9,es-ES;q=0.8', availableLocales: [], expected: 'en-GB'},
+    {header: 'en-GB,en;q=0.9,es-ES;q=0.8', availableLocales: ['es-ES', 'en-us'], expected: 'en-us'},
+    {header: 'en-GB,en;q=0.9,es-ES;q=0.8', availableLocales: ['es', 'en-us'], expected: 'en-us'},
+    {header: 'en-GB,en;q=0.9,es-ES;q=0.8', availableLocales: ['es', 'de'], expected: 'es'},
+    {header: 'en-GB,en;q=0.9,es-ES;q=0.8,de;q=0.6', availableLocales: ['es', 'de'], expected: 'es'},
+    {header: 'fr,fr-CA;q=0.9,en;q=0.8', availableLocales: ['fr-FR', 'en'], expected: 'fr-FR'},
+    {header: 'fr,fr-CA;q=0.9,en;q=0.8', availableLocales: ['fr-FR', 'fr-CA'], expected: 'fr-CA'},
+    {header: 'fr;q=0.9,en;q=0.8', availableLocales: ['fr-FR', 'fr-CA'], expected: 'fr-FR'},
+    {header: 'fr;q=0.9,en-US;q=0.8', availableLocales: ['fr-FR', 'en-US'], expected: 'fr-FR'},
     {header: 'en-GB,en;q=0.9,es-ES;q=0.8,en-US;q=0.6', availableLocales: ['de'], expected: undefined},
     {header: null, availableLocales: ['en-US'], expected: undefined},
     {header: '', availableLocales: ['en-US'], expected: undefined},
   ])('header: $header; availableLocales: $availableLocales', ({header, availableLocales, expected}) => {
     const result = getLocaleFromAcceptLanguageHeader(header, availableLocales);
-    expect(result?.toLowerCase()).toEqual(expected?.toLowerCase());
+    expect(result).toEqual(expected);
   });
 });


### PR DESCRIPTION
This pull request tries to solve the issue https://github.com/cibernox/precompile-intl-runtime/issues/31.

I rewrote the language matching algorithm to match more use cases. For example, if the Accept-Language header is `fr` and the availableLocales array is `['fr-FR']`, the function previously returned `undefined`. Still, it should return `fr-FR`, because `fr-FR` is actually a match for `fr`. But at the same time a header with value `fr, fr-CA` and availableLocales `['fr-FR', 'fr-CA']` should result in `fr-CA` and not `fr-FR`.  
The new matching algorithm is a bit more expensive, but I think this is the only way to solve all use cases.

I extended the unit tests also. If you think that I missed a use case, then I can extend the tests.