### PR TITLE
fix: pass options to Intl.NumberFormat

### DIFF
--- a/src/includes/formatters.ts
+++ b/src/includes/formatters.ts
@@ -26,7 +26,7 @@ export const getNumberFormatter: MemoizedIntlFormatter<
   if (typeof format === 'string') {
     return new Intl.NumberFormat(locale, getIntlFormatterOptions('number', format))
   } else {
-    return new Intl.NumberFormat(locale, format)
+    return new Intl.NumberFormat(locale, options)
   }
 })
 


### PR DESCRIPTION
When the "format" parameter ist not used, "getNumberFormatter()" now passes options to Intl.NumberFormat