### PR TITLE
Stricter null checking to not filter out empty strings

### DIFF
--- a/dist/modules/includes/lookup.js
+++ b/dist/modules/includes/lookup.js
@@ -20,7 +20,7 @@ export const lookup = (path, refLocale) => {
     for (let i = 0; i < locales.length; i++) {
         const locale = locales[i];
         const message = getMessageFromDictionary(locale, path);
-        if (message) {
+        if (message !== null) {
             // Used the requested locale as the cache key
             // Ex: { en: { title: "Title" }}
             // lookup('title', 'en-GB') should cache with 'en-GB' instead of 'en'

--- a/dist/modules/stores/dictionary.js
+++ b/dist/modules/stores/dictionary.js
@@ -22,7 +22,7 @@ export function getMessageFromDictionary(locale, id) {
         let tmpDict = localeDictionary;
         for (let i = 0; i < ids.length; i++) {
             if (typeof tmpDict[ids[i]] !== 'object') {
-                return tmpDict[ids[i]] || null;
+                return tmpDict[ids[i]] ?? null;
             }
             tmpDict = tmpDict[ids[i]];
         }

--- a/src/includes/lookup.ts
+++ b/src/includes/lookup.ts
@@ -28,7 +28,7 @@ export const lookup = (path: string, refLocale: string) => {
     const locale = locales[i];
     const message = getMessageFromDictionary(locale, path);
 
-    if (message) {
+    if (message !== null) {
       // Used the requested locale as the cache key
       // Ex: { en: { title: "Title" }}
       // lookup('title', 'en-GB') should cache with 'en-GB' instead of 'en'

--- a/src/stores/dictionary.ts
+++ b/src/stores/dictionary.ts
@@ -30,7 +30,7 @@ export function getMessageFromDictionary(locale: string, id: string) {
     let tmpDict: any = localeDictionary
     for (let i = 0; i < ids.length; i++) {
       if (typeof tmpDict[ids[i]] !== 'object') {
-        return (tmpDict[ids[i]] as LocaleDictionaryValue) || null
+        return (tmpDict[ids[i]] as LocaleDictionaryValue) ?? null
       }
       tmpDict = tmpDict[ids[i]];
     }


### PR DESCRIPTION
We have the problem that precopile-intl-runtime prints a warning to console that a message was not found in the language files, even if the message is present but is only an empty string. I found two places in the code of precompile-int-runtime that implicitly filters out empty strings. I have made these two places more strict so that empty strings won't be filtered out.