### PR TITLE
Accept-language headers can have whitespace between ; & q

### DIFF
--- a/src/includes/localeGetters.ts
+++ b/src/includes/localeGetters.ts
@@ -65,7 +65,7 @@ export const getLocaleFromAcceptLanguageHeader = (header: string | null, availab
       .split(',')
       .map(locale => locale.trim())
       .map(locale => {
-        const directives = locale.split(';q=');
+        const directives = locale.split(/; ?q=/);
         return {
           locale: directives[0],
           quality: parseFloat(directives[1]) || 1.0

--- a/tests/localeGetters.test.js
+++ b/tests/localeGetters.test.js
@@ -3,11 +3,13 @@ import {getLocaleFromAcceptLanguageHeader} from "../dist/modules";
 describe('getLocaleFromAcceptLanguageHeader', () => {
   it.each([
     {header: 'en-GB,en;q=0.9,es-ES;q=0.8', availableLocales: undefined, expected: 'en-GB'},
+    {header: 'en-GB,en; q=0.9,es-ES; q=0.8', availableLocales: undefined, expected: 'en-GB'},
     {header: 'en-GB,en;q=0.9,es-ES;q=0.8', availableLocales: [], expected: 'en-GB'},
     {header: 'en-GB,en;q=0.9,es-ES;q=0.8', availableLocales: ['es-ES', 'en-us'], expected: 'en-us'},
     {header: 'en-GB,en;q=0.9,es-ES;q=0.8', availableLocales: ['es', 'en-us'], expected: 'en-us'},
     {header: 'en-GB,en;q=0.9,es-ES;q=0.8', availableLocales: ['es', 'de'], expected: 'es'},
     {header: 'en-GB,en;q=0.9,es-ES;q=0.8,de;q=0.6', availableLocales: ['es', 'de'], expected: 'es'},
+    {header: 'en-GB,en; q=0.9,es-ES; q=0.8,de; q=0.6', availableLocales: ['es', 'de'], expected: 'es'},
     {header: 'fr,fr-CA;q=0.9,en;q=0.8', availableLocales: ['fr-FR', 'en'], expected: 'fr-FR'},
     {header: 'fr,fr-CA;q=0.9,en;q=0.8', availableLocales: ['fr-FR', 'fr-CA'], expected: 'fr-CA'},
     {header: 'fr;q=0.9,en;q=0.8', availableLocales: ['fr-FR', 'fr-CA'], expected: 'fr-FR'},


### PR DESCRIPTION
Resolves #45 