### PR TITLE
export warnOnMissingMessages config option

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -76,4 +76,5 @@ export interface ConfigureOptions {
   initialLocale?: string
   formats?: Partial<Formats>
   loadingDelay?: number
+  warnOnMissingMessages?: boolean
 }


### PR DESCRIPTION
Export the already existing config option `warnOnMissingMessages` in the `ConfigureOptions` interface.